### PR TITLE
IGNITE-14686  Incorrect type hint for the cache's get_all

### DIFF
--- a/pyignite/aio_cache.py
+++ b/pyignite/aio_cache.py
@@ -159,7 +159,7 @@ class AioCache(BaseCache):
         return await cache_put_async(conn, self.cache_info, key, value, key_hint=key_hint, value_hint=value_hint)
 
     @status_to_exception(CacheError)
-    async def get_all(self, keys: list) -> list:
+    async def get_all(self, keys: list) -> dict:
         """
         Retrieves multiple key-value pairs from cache.
 

--- a/pyignite/cache.py
+++ b/pyignite/cache.py
@@ -253,7 +253,7 @@ class Cache(BaseCache):
         )
 
     @status_to_exception(CacheError)
-    def get_all(self, keys: list) -> list:
+    def get_all(self, keys: list) -> dict:
         """
         Retrieves multiple key-value pairs from cache.
 


### PR DESCRIPTION
The docs for get_all show it returning a dict but the return type hint was erroneously a list.