### PR TITLE
IGNITE-15266 Add isclass check to is_hinted

### DIFF
--- a/pyignite/utils.py
+++ b/pyignite/utils.py
@@ -66,7 +66,8 @@ def is_hinted(value):
     """
     Check if a value is a tuple of data item and its type hint.
     """
-    return isinstance(value, tuple) and len(value) == 2 and issubclass(value[1], IgniteDataType)
+    return isinstance(value, tuple) and len(value) == 2 and inspect.isclass(value[1]) and \
+        issubclass(value[1], IgniteDataType)
 
 
 def int_overflow(value: int) -> int:

--- a/tests/common/test_datatypes.py
+++ b/tests/common/test_datatypes.py
@@ -166,6 +166,41 @@ async def test_put_get_data_async(async_cache, value, value_hint):
     assert await async_cache.get('my_key') == value
 
 
+nested_array_objects_params = [
+    [
+        (ObjectArrayObject.OBJECT, [
+            ((ObjectArrayObject.OBJECT, [
+                'test', 1, Value(1, 'test'),
+                ((ObjectArrayObject.OBJECT, ['test', 1, Value(1, 'test')]), ObjectArrayObject)
+            ]), ObjectArrayObject)
+        ]),
+        (ObjectArrayObject.OBJECT, [
+            (ObjectArrayObject.OBJECT, ['test', 1, Value(1, 'test'),
+                                        (ObjectArrayObject.OBJECT, ['test', 1, Value(1, 'test')])])
+        ])
+    ],
+]
+
+
+@pytest.mark.parametrize(
+    'hinted_value, value',
+    nested_array_objects_params
+)
+def test_put_get_nested_array_objects(cache, hinted_value, value):
+    cache.put('my_key', hinted_value, value_hint=ObjectArrayObject)
+    assert cache.get('my_key') == value
+
+
+@pytest.mark.parametrize(
+    'hinted_value, value',
+    nested_array_objects_params
+)
+@pytest.mark.asyncio
+async def test_put_get_nested_array_objects_async(async_cache, hinted_value, value):
+    await async_cache.put('my_key', hinted_value, value_hint=ObjectArrayObject)
+    assert await async_cache.get('my_key') == value
+
+
 bytearray_params = [
     ([1, 2, 3, 5], ByteArrayObject),
     ((7, 8, 13, 18), ByteArrayObject),


### PR DESCRIPTION
The issue seems to be caused by `issubclass` requiring its first parameter to be a class, which isn't the case for two-element tuples like the ones used by e.g. object arrays for hinting the object array type (`(-1, [...])`). Hence, an obvious patch would be to just double check that we are using it with a class.

Performance impact:
```bash
$ python -m timeit -r 25 -s "from inspect import isclass; a = int;" -- "isclass(a)"
2000000 loops, best of 25: 133 nsec per loop
$ python -m timeit -r 25 -s "from inspect import isclass; a = int;" -- "isclass(a) and issubclass(a, float)"
1000000 loops, best of 25: 236 nsec per loop
$ python -m timeit -r 25 -s "from inspect import isclass; a = [];" -- "isclass(a) and issubclass(a, float)"
2000000 loops, best of 25: 158 nsec per loop
$ python -m timeit -r 25 -s "a = int;" -- "try:" "  issubclass(a, float)" "except:" "  pass"
2000000 loops, best of 25: 114 nsec per loop
$ python -m timeit -r 25 -s "a = [];" -- "try:" "  issubclass(a, float)" "except:" "  pass"
1000000 loops, best of 25: 333 nsec per loop
```

Doesn't seem to impactful to me, we can do a million of those in a millisecond.